### PR TITLE
Adds a view to the Team page

### DIFF
--- a/src/AddTeamMemberForm.jsx
+++ b/src/AddTeamMemberForm.jsx
@@ -1,0 +1,67 @@
+import React, { PropTypes } from 'react'
+
+class AddTeamMemberForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      teamMemberName: "",
+      teamMemberTitle: "",
+    };
+    this.onChange = this.onChange.bind(this);
+    this.onNameChange = this.onNameChange.bind(this);
+    this.onTitleChange = this.onTitleChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+  onChange(key) {
+    // Return a curried function that sets a value to the key in this.state
+    return function(value) {
+      this.setState({
+        [key]: value
+      });
+    }.bind(this);
+  }
+  onNameChange(ev) {
+    this.onChange("teamMemberName")(ev.target.value);
+  }
+  onTitleChange(ev) {
+    this.onChange("teamMemberTitle")(ev.target.value);
+  }
+  onSubmit() {
+    const name = this.state.teamMemberName;
+    const title = this.state.teamMemberTitle;
+    this.props.onSubmit(name, title);
+  }
+  render() {
+    return (
+      <form onSubmit={this.onSubmit}>
+        <div>
+          <label htmlFor="teamMemberName">
+            Name:
+          </label>
+          <input
+            id="teamMemberName"
+            type="text"
+            value={this.state.teamMemberName}
+            onChange={this.onNameChange} />
+        </div>
+        <div>
+          <label htmlFor="teamMemberTitle">
+            Title:
+          </label>
+          <input
+            id="teamMemberTitle"
+            type="text"
+            value={this.state.teamMemberTitle}
+            onChange={this.onTitleChange} />
+        </div>
+        <button type="submit">Save</button>
+      </form>
+    );
+  }
+}
+
+AddTeamMemberForm.propTypes = {
+  onSubmit: PropTypes.func,
+};
+
+export default AddTeamMemberForm;

--- a/src/DeleteModal.jsx
+++ b/src/DeleteModal.jsx
@@ -1,0 +1,24 @@
+import React, { PropTypes } from 'react'
+import Button from 'react-bootstrap/lib/Button'
+
+function DeleteModal(props) {
+  function confirmDelete() {
+    props.shouldDelete(true);
+  }
+  function rejectDelete() {
+    props.shouldDelete(false);
+  }
+  return (
+    <div>
+      <h1>Are you sure?</h1>
+      <Button onClick={confirmDelete} name="Yes">Yes</Button>
+      <Button onClick={rejectDelete} name="No">No</Button>
+    </div>
+  );
+}
+
+DeleteModal.propTypes = {
+  shouldDelete: PropTypes.func.isRequired,
+};
+
+export default DeleteModal;

--- a/src/DeleteTeamMemberModal.jsx
+++ b/src/DeleteTeamMemberModal.jsx
@@ -1,0 +1,29 @@
+import React, {PropTypes} from 'react'
+import Button from 'react-bootstrap/lib/Button'
+
+class DeleteTeamMemberModal extends React.Component {
+  constructor(){
+    super();
+    this.confirm = this.confirm.bind(this);
+  }
+  render() {
+    return (
+      <div>
+        <h1>Are you sure?</h1>
+        <Button onClick={this.confirm} name="Yes">Yes</Button>
+        <Button onClick={this.props.closeModal} name="No">No</Button>
+      </div>
+    );
+  }
+  confirm() {
+    this.props.doDelete();
+    this.props.closeModal();
+  }
+}
+
+DeleteTeamMemberModal.propTypes = {
+  doDelete: PropTypes.func,
+  closeModal: PropTypes.func
+}
+
+export default DeleteTeamMemberModal;

--- a/src/DeleteTeamMemberModal.test.jsx
+++ b/src/DeleteTeamMemberModal.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow, mount } from 'enzyme';
+import DeleteTeamMemberModal from './DeleteTeamMemberModal.jsx';
+
+describe('<DeleteTeamMemberModal />', () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<DeleteTeamMemberModal />, div);
+  });
+
+  it('matches the stored snapshot', () => {
+    const wrapper = shallow(<DeleteTeamMemberModal />);
+    expect(wrapper.get(0)).toMatchSnapshot();
+  });
+
+  describe('the Yes button', () => {
+    it('triggers a delete callback and closes the modal when clicked', () => {
+      let didDelete = false, didClose = false;
+      const mockDelete = () => {didDelete = true; };
+      const mockClose = () => {didClose = true; };
+      const node = shallow(<DeleteTeamMemberModal
+        doDelete={mockDelete}
+        closeModal={mockClose} />);
+      const button = node.find("Button")
+        .findWhere(n => n.prop('name') == "Yes");
+      button.simulate('click');
+      expect(didClose && didDelete).toBe(true);
+    });
+  });
+
+  describe('the No button', () => {
+    it('closes the modal and does not trigger a delete when clicked', () => {
+      let didDelete = false, didClose = false;
+      const mockDelete = () => {didDelete = true; };
+      const mockClose = () => {didClose = true; };
+      const node = shallow(<DeleteTeamMemberModal
+        doDelete={mockDelete}
+        closeModal={mockClose} />);
+      const button = node.find("Button")
+        .findWhere(n => n.prop('name') == "No");
+      button.simulate('click');
+      expect(didClose).toBe(true);
+      expect(didDelete).toBe(false);
+    });
+  });
+});

--- a/src/Skills.jsx
+++ b/src/Skills.jsx
@@ -62,8 +62,6 @@ class Skills extends Component {
     axios.get(api + '/skills/' + value)
       .then(res => {
         const skillresults = res.data
-        console.log(value)
-        console.log(skillresults)
         this.setState(
           {currentSkill: {
             skill_id: skillresults.id,
@@ -165,16 +163,17 @@ class Skills extends Component {
               <Select
                 name="skills"
                 labelKey="name"
-                value={this.state.skill_type}
                 onChange={onSkillChange}
+                value={this.state.currentSkill.skill_type}
+                onChange={onSkillTypeChange}
                 options={this.state.skills}
               />
             </Col>
-            <Button name="AddSkill"
-                    bsStyle="primary"
-                    onClick={this.openSkillModal}>
-              Add Skill
-            </Button>
+            <Button
+              name="SkillAdd"
+              bsStyle="primary"
+              onClick={this.openModal}
+              children="Add Skill" />
             <Modal
               isOpen={this.state.skillModalIsOpen}
               onRequestClose={this.closeSkillModal}
@@ -240,4 +239,4 @@ function capitalizeFirstLetter(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-export default Skills
+export default Skills;

--- a/src/Skills.jsx
+++ b/src/Skills.jsx
@@ -165,14 +165,13 @@ class Skills extends Component {
                 labelKey="name"
                 onChange={onSkillChange}
                 value={this.state.currentSkill.skill_type}
-                onChange={onSkillTypeChange}
                 options={this.state.skills}
               />
             </Col>
             <Button
-              name="SkillAdd"
+              name="AddSkill"
               bsStyle="primary"
-              onClick={this.openModal}
+              onClick={this.openSkillModal}
               children="Add Skill" />
             <Modal
               isOpen={this.state.skillModalIsOpen}

--- a/src/Skills.jsx
+++ b/src/Skills.jsx
@@ -171,8 +171,11 @@ class Skills extends Component {
             <Button
               name="AddSkill"
               bsStyle="primary"
-              onClick={this.openSkillModal}
-              children="Add Skill" />
+              onClick={this.openSkillModal} >
+              Add Skill
+            </Button>
+
+
             <Modal
               isOpen={this.state.skillModalIsOpen}
               onRequestClose={this.closeSkillModal}

--- a/src/Team.jsx
+++ b/src/Team.jsx
@@ -1,19 +1,171 @@
 import React from 'react';
+import 'bootstrap/dist/css/bootstrap.css';
+import Button from 'react-bootstrap/lib/Button';
+import Modal from 'react-modal';
+import { Row, Col }  from 'react-bootstrap';
+import axios from 'axios';
+import Select from 'react-select';
 
-function Skills(props) {
-  return (
-    <div>
-      <h1>The Team</h1>
-      <ul>
-        <li>Brian</li>
-        <li>Andrew</li>
-        <li>Jordan</li>
-        <li>Jeff</li>
-        <li>Dane</li>
-        <li>Joel</li>
-      </ul>
-    </div>
-  );
+import AddTeamMemberForm from './AddTeamMemberForm.jsx';
+import TeamMemberDisplay from './TeamMemberDisplay.jsx';
+import DeleteModal from './DeleteModal.jsx';
+
+var api = (process.env.REACT_APP_API);
+
+class Team extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      teamMembers: [],
+      addModalIsOpen: false,
+      deleteModalIsOpen: false,
+      selectedTeamMember: {
+        id: "",
+        name: "",
+        title: "",
+      }
+    };
+
+    this.fetchTeamMembers = this.fetchTeamMembers.bind(this);
+    this.openAddModal = this.openAddModal.bind(this);
+    this.closeAddModal = this.closeAddModal.bind(this);
+    this.openDeleteModal = this.openDeleteModal.bind(this);
+    this.closeDeleteModal = this.closeDeleteModal.bind(this);
+    this.onSelectChange = this.onSelectChange.bind(this);
+    this.addTeamMember = this.addTeamMember.bind(this);
+    this.shouldDelete = this.shouldDelete.bind(this);
+  }
+
+  openAddModal() {
+    this.setState({ addModalIsOpen: true });
+  }
+
+  closeAddModal() {
+    this.setState({ addModalIsOpen: false });
+  }
+
+  openDeleteModal() {
+    this.setState({ deleteModalIsOpen: true });
+  }
+
+  closeDeleteModal() {
+    this.setState({ deleteModalIsOpen: false });
+  }
+
+  fetchTeamMembers() {
+    axios.get(`${api}/teammembers/`)
+      .then((result) => {
+        const teamMembers = result.data.slice();
+        this.setState({
+          teamMembers: teamMembers
+        });
+      })
+      .catch((err) => {
+        console.log(`Error fetching team members: ${err}`);
+      });
+  }
+
+  onSelectChange(obj) {
+    axios.get(`${api}/teammembers/${obj.id}`)
+      .then((result) => {
+        const teamMemberData = result.data;
+        this.setState({
+          selectedTeamMember: {
+            id: teamMemberData.id,
+            name: teamMemberData.name,
+            title: teamMemberData.title,
+          }
+        });
+      }).catch((err) => {
+        console.log(`Error: ${err}`);
+      });
+  }
+
+  addTeamMember(name, title) {
+    axios.post(`${api}/teammembers/`, {
+      name: name,
+      title: title
+    }).then((response) => {
+        this.closeAddModal();
+        this.fetchTeamMembers();
+      }).catch(err => {
+        console.log(`Error: ${err}`);
+      });
+  }
+  shouldDelete(response) {
+    if (response) {
+      this.deleteTeamMember();
+    }
+    this.closeDeleteModal();
+  }
+
+  deleteTeamMember() {
+    axios.delete(`${api}/teammembers/${this.state.selectedTeamMember.id}`)
+      .then(function(result) {
+        this.setState({
+          selectedTeamMember: {
+            id: "",
+            name: "",
+            title: "",
+          }
+        });
+        // Refetch the list of team members
+        this.fetchTeamMembers();
+      }.bind(this))
+      .catch((err) => {
+        console.log(`Error: ${err}`);
+      });
+  }
+
+  componentDidMount() {
+    this.fetchTeamMembers();
+  }
+
+  render() {
+    return (
+      <div>
+        <Row>
+          <Col xs={4} md={4}>
+            <Select
+              name="teamMembers"
+              labelKey="name"
+              value={this.state.selectedTeamMember.name}
+              options={this.state.teamMembers}
+              onChange={this.onSelectChange} />
+          </Col>
+          <Button
+            name="addTeamMember"
+            bsStyle="primary"
+            onClick={this.openAddModal}
+            children="Add Team Member" />
+
+          <Modal
+            isOpen={this.state.addModalIsOpen}
+            onRequestClose={this.closeAddModal}
+            contentLabel="AddTeamMemberModal" >
+            <AddTeamMemberForm
+              onSubmit={this.addTeamMember} />
+          </Modal>
+        </Row>
+        <TeamMemberDisplay
+          selected={this.state.selectedTeamMember} />
+
+        <Button
+          name="TeamMemberDelete"
+          bsStyle="danger"
+          onClick={this.openDeleteModal}
+          disabled={this.state.selectedTeamMember.id === ""}
+          children='Delete' />
+        <Modal
+          isOpen={this.state.deleteModalIsOpen}
+          onRequestClose={this.closeDeleteModal}
+          contentLabel="DeleteTeamMemberModal" >
+          <DeleteModal
+            shouldDelete={this.shouldDelete}/>
+        </Modal>
+      </div>
+    );
+  }
 }
 
-export default Skills
+export default Team;

--- a/src/Team.jsx
+++ b/src/Team.jsx
@@ -8,7 +8,7 @@ import Select from 'react-select';
 
 import AddTeamMemberForm from './AddTeamMemberForm.jsx';
 import TeamMemberDisplay from './TeamMemberDisplay.jsx';
-import DeleteModal from './DeleteModal.jsx';
+import DeleteTeamMemberModal from './DeleteTeamMemberModal.jsx';
 
 var api = (process.env.REACT_APP_API);
 
@@ -34,6 +34,7 @@ class Team extends React.Component {
     this.onSelectChange = this.onSelectChange.bind(this);
     this.addTeamMember = this.addTeamMember.bind(this);
     this.shouldDelete = this.shouldDelete.bind(this);
+    this.deleteTeamMember = this.deleteTeamMember.bind(this);
   }
 
   openAddModal() {
@@ -101,7 +102,7 @@ class Team extends React.Component {
 
   deleteTeamMember() {
     axios.delete(`${api}/teammembers/${this.state.selectedTeamMember.id}`)
-      .then(function(result) {
+      .then((result) => {
         this.setState({
           selectedTeamMember: {
             id: "",
@@ -111,7 +112,7 @@ class Team extends React.Component {
         });
         // Refetch the list of team members
         this.fetchTeamMembers();
-      }.bind(this))
+      })
       .catch((err) => {
         console.log(`Error: ${err}`);
       });
@@ -149,7 +150,6 @@ class Team extends React.Component {
         </Row>
         <TeamMemberDisplay
           selected={this.state.selectedTeamMember} />
-
         <Button
           name="TeamMemberDelete"
           bsStyle="danger"
@@ -160,8 +160,9 @@ class Team extends React.Component {
           isOpen={this.state.deleteModalIsOpen}
           onRequestClose={this.closeDeleteModal}
           contentLabel="DeleteTeamMemberModal" >
-          <DeleteModal
-            shouldDelete={this.shouldDelete}/>
+          <DeleteTeamMemberModal
+            doDelete={this.deleteTeamMember}
+            closeModal={this.closeDeleteModal} />
         </Modal>
       </div>
     );

--- a/src/Team.test.jsx
+++ b/src/Team.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
-import Team from './Team';
+import { shallow, mount } from 'enzyme';
+import Team from './Team.jsx';
 
 describe('<Team />', () => {
   it('renders without crashing', () => {
@@ -12,5 +12,38 @@ describe('<Team />', () => {
   it('matches the stored snapshot', () => {
     const wrapper = shallow(<Team />);
     expect(wrapper.get(0)).toMatchSnapshot();
+  });
+
+  it('has a Button that opens the SkillModal', () => {
+    const wrapper = mount(<Team />);
+    const skillModal = wrapper.find('Modal')
+      .findWhere(n => n.prop('contentLabel') == 'AddTeamMemberModal');
+    const addSkillButton = wrapper.find('button')
+      .findWhere(n => n.prop('name') == 'addTeamMember');
+    expect(skillModal.prop('isOpen')).toBe(false);
+    addSkillButton.simulate('click');
+    expect(skillModal.prop('isOpen')).toBe(true);
+  });
+
+  describe('the Delete Button', function () {
+    it('should be disabled if a team member is not selected', function () {
+      const teamComponent = mount(<Team />);
+      const button = teamComponent.find('button')
+        .findWhere(n => n.prop('name') == "TeamMemberDelete");
+      expect(button.prop('disabled')).toBe(true);
+      teamComponent.setState({ selectedTeamMember: { skill_id: "1234", }});
+      expect(button.prop('disabled')).toBe(false);
+    });
+    it('Can open a DeleteTeamMemberModal when a team member has been selected', () => {
+      const wrapper = mount(<Team />);
+      wrapper.setState({ selectedTeamMember: { id: "1" }});
+      const node = wrapper.find('Modal')
+        .findWhere(n => n.prop('contentLabel') == "DeleteTeamMemberModal");
+      const button = wrapper.find('button')
+        .findWhere(n => n.prop('name') == "TeamMemberDelete");
+      expect(node.prop('isOpen')).toBe(false);
+      button.simulate('click');
+      expect(node.prop('isOpen')).toBe(true);
+    });
   });
 });

--- a/src/TeamMemberDisplay.jsx
+++ b/src/TeamMemberDisplay.jsx
@@ -1,0 +1,17 @@
+import React, { PropTypes } from 'react';
+
+const TeamMemberDisplay = ({selected}) => (
+  <div>
+    <h1>Name: {selected.name}</h1>
+    <h2>Title: {selected.title}</h2>
+  </div>
+);
+
+TeamMemberDisplay.propTypes = {
+  selected: PropTypes.shape({
+    name: PropTypes.string,
+    title: PropTypes.string,
+  })
+};
+
+export default TeamMemberDisplay;

--- a/src/__snapshots__/DeleteTeamMemberModal.test.jsx.snap
+++ b/src/__snapshots__/DeleteTeamMemberModal.test.jsx.snap
@@ -1,0 +1,27 @@
+exports[`<DeleteTeamMemberModal /> matches the stored snapshot 1`] = `
+<div>
+  <h1>
+    Are you sure?
+  </h1>
+  <Button
+    active={false}
+    block={false}
+    bsClass="btn"
+    bsStyle="default"
+    disabled={false}
+    name="Yes"
+    onClick={[Function]}>
+    Yes
+  </Button>
+  <Button
+    active={false}
+    block={false}
+    bsClass="btn"
+    bsStyle="default"
+    disabled={false}
+    name="No"
+    onClick={undefined}>
+    No
+  </Button>
+</div>
+`;

--- a/src/__snapshots__/Skills.test.jsx.snap
+++ b/src/__snapshots__/Skills.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`<Skills /> matches the stored snapshot 1`] = `
         searchable={true}
         simpleValue={false}
         tabSelectsValue={true}
-        value={undefined}
+        value=""
         valueComponent={[Function]}
         valueKey="value" />
     </Col>

--- a/src/__snapshots__/Team.test.jsx.snap
+++ b/src/__snapshots__/Team.test.jsx.snap
@@ -1,27 +1,108 @@
 exports[`<Team /> matches the stored snapshot 1`] = `
 <div>
-  <h1>
-    The Team
-  </h1>
-  <ul>
-    <li>
-      Brian
-    </li>
-    <li>
-      Andrew
-    </li>
-    <li>
-      Jordan
-    </li>
-    <li>
-      Jeff
-    </li>
-    <li>
-      Dane
-    </li>
-    <li>
-      Joel
-    </li>
-  </ul>
+  <Row
+    bsClass="row"
+    componentClass="div">
+    <Col
+      bsClass="col"
+      componentClass="div"
+      md={4}
+      xs={4}>
+      <Select
+        addLabelText="Add \"{label}\"?"
+        arrowRenderer={[Function]}
+        autosize={true}
+        backspaceRemoves={true}
+        backspaceToRemoveMessage="Press backspace to remove {label}"
+        clearAllText="Clear all"
+        clearValueText="Clear value"
+        clearable={true}
+        delimiter=","
+        disabled={false}
+        escapeClearsValue={true}
+        filterOptions={[Function]}
+        ignoreAccents={true}
+        ignoreCase={true}
+        inputProps={Object {}}
+        isLoading={false}
+        joinValues={false}
+        labelKey="name"
+        matchPos="any"
+        matchProp="any"
+        menuBuffer={0}
+        menuRenderer={[Function]}
+        multi={false}
+        name="teamMembers"
+        noResultsText="No results found"
+        onBlurResetsInput={true}
+        onChange={[Function]}
+        onCloseResetsInput={true}
+        openAfterFocus={false}
+        optionComponent={[Function]}
+        options={Array []}
+        pageSize={5}
+        placeholder="Select..."
+        required={false}
+        scrollMenuIntoView={true}
+        searchable={true}
+        simpleValue={false}
+        tabSelectsValue={true}
+        value=""
+        valueComponent={[Function]}
+        valueKey="value" />
+    </Col>
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="primary"
+      disabled={false}
+      name="addTeamMember"
+      onClick={[Function]}>
+      Add Team Member
+    </Button>
+    <Modal
+      ariaHideApp={true}
+      closeTimeoutMS={0}
+      contentLabel="AddTeamMemberModal"
+      isOpen={false}
+      onRequestClose={[Function]}
+      parentSelector={[Function]}
+      portalClassName="ReactModalPortal"
+      shouldCloseOnOverlayClick={true}>
+      <AddTeamMemberForm
+        onSubmit={[Function]} />
+    </Modal>
+  </Row>
+  <TeamMemberDisplay
+    selected={
+      Object {
+        "id": "",
+        "name": "",
+        "title": "",
+      }
+    } />
+  <Button
+    active={false}
+    block={false}
+    bsClass="btn"
+    bsStyle="danger"
+    disabled={true}
+    name="TeamMemberDelete"
+    onClick={[Function]}>
+    Delete
+  </Button>
+  <Modal
+    ariaHideApp={true}
+    closeTimeoutMS={0}
+    contentLabel="DeleteTeamMemberModal"
+    isOpen={false}
+    onRequestClose={[Function]}
+    parentSelector={[Function]}
+    portalClassName="ReactModalPortal"
+    shouldCloseOnOverlayClick={true}>
+    <DeleteModal
+      shouldDelete={[Function]} />
+  </Modal>
 </div>
 `;

--- a/src/__snapshots__/Team.test.jsx.snap
+++ b/src/__snapshots__/Team.test.jsx.snap
@@ -101,8 +101,9 @@ exports[`<Team /> matches the stored snapshot 1`] = `
     parentSelector={[Function]}
     portalClassName="ReactModalPortal"
     shouldCloseOnOverlayClick={true}>
-    <DeleteModal
-      shouldDelete={[Function]} />
+    <DeleteTeamMemberModal
+      closeModal={[Function]}
+      doDelete={[Function]} />
   </Modal>
 </div>
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
+import App from './App.jsx';
 
 ReactDOM.render(
   <App />,


### PR DESCRIPTION
Fixed Issue #15 

This PR adds a view to the Team page that is similar to the Skills page, sans links functionality. A user will be able to add a team member and delete him/her. I also added a generic DeleteModal component that is stateless and can be used to trigger a `shouldDelete()` that will handle deleting an item (or not) and closing the DeleteModal. 

I have not written tests yet but those will be added. I am making this PR to allow other eyes to see this code.