### PR TITLE
Fixed issue by migrating http server from python SimpleHTTPServer to pushstate-server

### DIFF
--- a/buildUI
+++ b/buildUI
@@ -6,4 +6,4 @@ fi
 
 REACT_APP_API=$API npm run build
 
-cd build && python -m SimpleHTTPServer 9000
+cd build && pushstate-server .

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "webpack": "^1.14.0"
   },
   "dependencies": {
+    "pushstate-server": "^2.1.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-router-bootstrap": "^0.23.1"


### PR DESCRIPTION
Fixes #47 

Migrates from python's SimpleHttpServer module to pushstate-server https://github.com/scottcorgan/pushstate-server.

Should fix the issue with the 404's