### PR TITLE
SkillForm is now AddSkillForm

### DIFF
--- a/src/AddSkillForm.jsx
+++ b/src/AddSkillForm.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import axios from 'axios';
+import React, { PropTypes } from 'react';
 import { Col, ControlLabel, Button,
    Form, FormControl, FormGroup } from 'react-bootstrap'
 
@@ -10,7 +9,15 @@ const skillTypes = [
   { value: 'orchestration', label: 'Orchestration' }
 ];
 
-class SkillForm extends React.Component {
+const options = skillTypes.map((type, index) => {
+  return (
+    <option key={index} value={type.value}>
+      {type.label}
+    </option>
+  );
+});
+
+class AddSkillForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -18,37 +25,36 @@ class SkillForm extends React.Component {
       skill_type: skillTypes[0].value
     };
     this.onChange = this.onChange.bind(this);
+    this.onNameChange = this.onNameChange.bind(this);
+    this.onTypeChange = this.onTypeChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
   }
 
-  onChange(key, value) {
-    this.setState({ [key]: value});
+  onChange(key) {
+    return (value) => {
+      this.setState({
+        [key]: value
+      });
+    }
+  }
+
+  onNameChange(ev) {
+    this.onChange("skill_name")(ev.target.value);
+  }
+
+  onTypeChange(ev) {
+    this.onChange("skill_type")(ev.target.value);
   }
 
   onSubmit(ev) {
     ev.preventDefault();
-    const skill_name = this.state.skill_name;
-    const skill_type = this.state.skill_type;
-
-    axios.post(this.props.api + '/skills/', {
-        name: skill_name,
-        skill_type: skill_type
-    })
-    .then(function (response) {
-      console.log(response);
-      this.props.closeModal();
-    }.bind(this))
-    .catch(err => {
-      console.log('caught an error', err);
-    });
+    this.props.onSubmit(
+      this.state.skill_name,
+      this.state.skill_type
+    );
   }
 
   render() {
-    const onSkillNameChange = ev => this.onChange("skill_name", ev.target.value);
-    const onSkillTypeChange = ev => this.onChange("skill_type", ev.target.value);
-    const options = skillTypes.map(type =>
-       (<option key={type.value} value={type.value}>{type.label}</option>)
-       );
     return (
       <div>
         <h1>Add Skill</h1>
@@ -58,7 +64,7 @@ class SkillForm extends React.Component {
               Name:
             </Col>
             <Col sm={10}>
-              <FormControl name='skillName' onChange={onSkillNameChange}/>
+              <FormControl name='skillName' onChange={this.onNameChange}/>
             </Col>
           </FormGroup>
           <FormGroup controlId='skillType'>
@@ -66,7 +72,7 @@ class SkillForm extends React.Component {
               Type:
             </Col>
             <Col sm={10}>
-              <FormControl componentClass="select" onChange={onSkillTypeChange}>
+              <FormControl componentClass="select" onChange={this.onTypeChange}>
                 {options}
               </FormControl>
             </Col>
@@ -89,4 +95,8 @@ class SkillForm extends React.Component {
   }
 }
 
-export default SkillForm
+AddSkillForm.propTypes = {
+  onSubmit: PropTypes.func,
+};
+
+export default AddSkillForm

--- a/src/AddSkillForm.test.jsx
+++ b/src/AddSkillForm.test.jsx
@@ -1,22 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import SkillsForm from './SkillsForm';
+import AddSkillForm from './AddSkillForm.jsx';
 import { shallow } from 'enzyme';
 import { mount } from 'enzyme';
 
-describe('<SkillsForm />', () => {
+describe('<AddSkillForm />', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');
-    ReactDOM.render(<SkillsForm />, div);
+    ReactDOM.render(<AddSkillForm />, div);
   });
 
   it('matches the stored snapshot', () => {
-    const wrapper = shallow(<SkillsForm />);
+    const wrapper = shallow(<AddSkillForm />);
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('changes state when input to "Name:" field changes', () => {
-    const wrapper = mount(<SkillsForm />);
+    const wrapper = mount(<AddSkillForm />);
     // process.stdout.write(wrapper.debug());
     // process.stdout.write(JSON.stringify(wrapper.state()));
     expect(wrapper.state().skill_name).toBe("");
@@ -30,7 +30,7 @@ describe('<SkillsForm />', () => {
 // the "Select" element we are using from 'react-select' doesn't respond
 // as expected to the simulated "change" event.
   // it('changes state when selected option in "Skill Type" field changes', () => {
-  //   const wrapper = mount(<SkillsForm />);
+  //   const wrapper = mount(<AddSkillForm />);
   //   expect(wrapper.state().skill_type).toBe("");
   //   const event = {target: {value: "New Value"}};
   //   wrapper.find("Select").simulate("change", event);

--- a/src/Skills.jsx
+++ b/src/Skills.jsx
@@ -7,7 +7,7 @@ import { Row, Col }  from 'react-bootstrap'
 import axios from 'axios'
 import LinkForm from './LinksForm'
 import ReviewForm from './SkillReviewsForm.jsx'
-import SkillForm from './SkillsForm'
+import AddSkillForm from './AddSkillForm.jsx';
 import { ModalStyle } from './Styles'
 import DeleteModal from './DeleteModal.jsx';
 import DeleteButton from './DeleteButton.jsx';
@@ -46,7 +46,7 @@ class Skills extends Component {
     this.openDeleteModal = this.openDeleteModal.bind(this);
     this.closeDeleteModal = this.closeDeleteModal.bind(this);
 
-    this.reloadSkills = this.reloadSkills.bind(this);
+    this.addSkill = this.addSkill.bind(this);
     this.deleteSkill = this.deleteSkill.bind(this);
     this.onChange = this.onChange.bind(this);
     this.shouldDelete = this.shouldDelete.bind(this);
@@ -76,7 +76,6 @@ class Skills extends Component {
             links: skillresults.links,
           }});
           browserHistory.push('/skills/' + skillresults.id);
-        // console.log(res.data);
       })
       .catch(err => {
         console.log(err);
@@ -88,6 +87,20 @@ class Skills extends Component {
       this.deleteSkill();
     }
     this.closeDeleteModal();
+  }
+
+  addSkill(skill_name, skill_type) {
+    axios.post(`${api}/skills/`, {
+      name: skill_name,
+      skill_type: skill_type,
+    })
+      .then(() => {
+        this.closeSkillModal();
+        this.loadSkills();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
   }
 
   deleteSkill() {
@@ -110,17 +123,7 @@ class Skills extends Component {
      });
   }
 
-  reloadSkills() {
-    axios.get(api + '/skills/')
-      .then(res => {
-        const skills = res.data.map(obj => obj);
-        this.setState({ skills: skills });
-      });
-  }
-
   componentDidMount() {
-    console.log(process.env)
-    this.reloadSkills();
     const currentId = (this.props.params) ? this.props.params.id : null;
     if (!currentId) {
       this.loadSkills();
@@ -131,13 +134,14 @@ class Skills extends Component {
 
   loadSkills(){
     return axios.get(`${api}/skills/`)
-      .then(res => {
-        const data = res.data;
-        const skills = data.map(obj => obj);
-        this.setState({ skills });
+      .then((response) => {
+        const skills = response.data.slice();
+        this.setState({
+          skills: skills
+        });
       })
-      .catch(err => {
-        console.log(err)
+      .catch((err) => {
+        console.log(err);
       });
   }
 
@@ -238,8 +242,9 @@ class Skills extends Component {
               onRequestClose={this.closeSkillModal}
               contentLabel="SkillModal"
             >
-              <SkillForm api={api}
-                         closeModal={this.closeSkillModal} />
+              <AddSkillForm
+                onSubmit={this.addSkill}
+              />
             </Modal>
             <Modal
               isOpen={this.state.linkModalIsOpen}

--- a/src/Skills.test.jsx
+++ b/src/Skills.test.jsx
@@ -61,7 +61,7 @@ describe('<Skills />', () => {
       const addReviewButton = wrapper.find('[name="AddReview"]');
       expect(addReviewButton).toHaveLength(1);
     });
-    it('opens a DeleteModal when clicked', () => {
+    it('opens a SkillReviewsForm when clicked', () => {
       const wrapper = mount(<Skills />);
       wrapper.setState({ currentSkill: { skill_id: "1" }});
       const addReviewModal = wrapper.find('Modal').

--- a/src/__snapshots__/AddSkillForm.test.jsx.snap
+++ b/src/__snapshots__/AddSkillForm.test.jsx.snap
@@ -1,4 +1,4 @@
-exports[`<SkillsForm /> matches the stored snapshot 1`] = `
+exports[`<AddSkillForm /> matches the stored snapshot 1`] = `
 <div>
   <h1>
     Add Skill

--- a/src/__snapshots__/Skills.test.jsx.snap
+++ b/src/__snapshots__/Skills.test.jsx.snap
@@ -70,9 +70,8 @@ exports[`<Skills /> matches the stored snapshot 1`] = `
       parentSelector={[Function]}
       portalClassName="ReactModalPortal"
       shouldCloseOnOverlayClick={true}>
-      <SkillForm
-        api="http://localhost:8080"
-        closeModal={[Function]} />
+      <AddSkillForm
+        onSubmit={[Function]} />
     </Modal>
     <Modal
       ariaHideApp={true}


### PR DESCRIPTION
Fixes #60 
Fixes #82 
- SkillsForm was renamed to AddSkillForm to better denote its functionality
- POST request to add skill moved to Skill component, as well as handling closing the AddSkillForm and reloading the skills