### PR TITLE
Check ev.target.value in onPositiveChange in SkillReviewsForm

### DIFF
--- a/src/AddSkillForm.jsx
+++ b/src/AddSkillForm.jsx
@@ -39,11 +39,11 @@ class AddSkillForm extends React.Component {
   }
 
   onNameChange(ev) {
-    this.onChange("skill_name")(ev.target.value);
+    this.onChange('skill_name')(ev.target.value);
   }
 
   onTypeChange(ev) {
-    this.onChange("skill_type")(ev.target.value);
+    this.onChange('skill_type')(ev.target.value);
   }
 
   onSubmit(ev) {

--- a/src/SkillReviewsForm.jsx
+++ b/src/SkillReviewsForm.jsx
@@ -1,25 +1,31 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import axios from 'axios';
-import {Col, ControlLabel, Button, 
-  Form, FormControl, FormGroup } from 'react-bootstrap'
+import { Button,
+  Col,
+  ControlLabel,
+  Form,
+  FormControl,
+FormGroup } from 'react-bootstrap';
 
 class SkillReviewsForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       teamMembers: null,
-      team_member_id: "",
+      team_member_id: '',
       positive: true,
-      body:     '',
+      body: '',
     };
     this.onChange = this.onChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
+    this.onPositiveChange = this.onPositiveChange.bind(this);
+    this.onBodyChange = this.onBodyChange.bind(this);
+    this.onTeamMemberChange = this.onTeamMemberChange.bind(this);
   }
 
   componentDidMount() {
     axios.get(`${this.props.api}/teammembers/`)
       .then((result) => {
-        console.log(result.data);
         this.setState({ teamMembers: result.data });
       })
       .catch((err) => {
@@ -27,18 +33,39 @@ class SkillReviewsForm extends React.Component {
       });
   }
 
-  onChange(key, value) {
-    this.setState({ [key]: value });
+  onChange(key) {
+    return (value) => {
+      this.setState({
+        [key]: value,
+      });
+    };
+  }
+
+  onPositiveChange(ev) {
+    // ev.target.value is guaranteed to be a string type so we have to check
+    // the contents of ev.target.value
+    // I would like to throw an error here since there is something WRONG
+    // if ev.target.value is neither 'true' or 'false'
+    const isPositive = ev.target.value === 'true';
+    this.onChange('positive')(isPositive);
+  }
+
+  onBodyChange(ev) {
+    this.onChange('body')(ev.target.value);
+  }
+
+  onTeamMemberChange(ev) {
+    this.onChange('team_member_id')(ev.target.value);
   }
 
   onSubmit(ev) {
     ev.preventDefault();
     // Error Checking
-    if(this.state.body === '') {
+    if (this.state.body === '') {
       alert('Cannot submit empty review.');
       return;
     }
-    if(this.state.team_member_id === '') {
+    if (this.state.team_member_id === '') {
       alert('Please select a Team Member.');
       return;
     }
@@ -61,16 +88,13 @@ class SkillReviewsForm extends React.Component {
   }
 
   render() {
-    const onPositiveChange = ev => this.onChange('positive', ev.target.value);
-    const onBodyChange = ev => this.onChange('body', ev.target.value);
-    const onTeamMemberChange = ev =>
-      this.onChange('team_member_id', ev.target.value);
     let teamMembers = null;
-    if(this.state.teamMembers != null) {
+    if (this.state.teamMembers != null) {
       teamMembers = this.state.teamMembers.map(teamMember =>
-        <option 
-          key={teamMember.id} 
-          value={teamMember.id}>
+        <option
+          key={teamMember.id}
+          value={teamMember.id}
+        >
           {teamMember.name}
         </option>
       );
@@ -79,50 +103,53 @@ class SkillReviewsForm extends React.Component {
       <div>
         <h1>Add Skill Review</h1>
         <Form horizontal onSubmit={this.onSubmit}>
-          <FormGroup controlId='teamMember'>
+          <FormGroup controlId="teamMember">
             <Col componentClass={ControlLabel} sm={4}>
               Select a Team Member:
             </Col>
             <Col sm={8}>
               <FormControl
-                name='teamMemberSelect'
-                componentClass='select'
-                onChange={onTeamMemberChange}>
+                name="teamMemberSelect"
+                componentClass="select"
+                onChange={this.onTeamMemberChange}
+              >
                 <option key={0} value={null} />
                 {teamMembers}
               </FormControl>
             </Col>
           </FormGroup>
-          <FormGroup controlId='reviewPositive'>
+          <FormGroup controlId="reviewPositive">
             <Col componentClass={ControlLabel} sm={4}>
               Is This a Positive Review?
             </Col>
             <Col sm={8}>
-              <FormControl 
-                name='positiveSelect'
-                componentClass='select' 
-                onChange={onPositiveChange}>
-                <option key={true} value={true}>Yes</option>
-                <option key={false} value={false}>No</option>
+              <FormControl
+                name="positiveSelect"
+                componentClass="select"
+                onChange={this.onPositiveChange}
+              >
+                <option value="true">Yes</option>
+                <option value="false">No</option>
               </FormControl>
             </Col>
           </FormGroup>
-          <FormGroup controlId='reviewBody'>
+          <FormGroup controlId="reviewBody">
             <Col componentClass={ControlLabel} sm={2}>
               Review:
             </Col>
             <Col sm={10}>
               <FormControl
-                name='reviewBody'
-                componentClass='textarea'
+                name="reviewBody"
+                componentClass="textarea"
                 style={{ height: 150 }}
-                onChange={onBodyChange}/>
+                onChange={this.onBodyChange}
+              />
             </Col>
           </FormGroup>
           <FormGroup>
             <Col smOffset={2} sm={10}>
-              <Button type='submit' bsStyle='primary'>
-                Submit 
+              <Button type="submit" bsStyle="primary">
+                Submit
               </Button>
             </Col>
           </FormGroup>
@@ -132,4 +159,10 @@ class SkillReviewsForm extends React.Component {
   }
 }
 
-export default SkillReviewsForm
+SkillReviewsForm.propTypes = {
+  api: PropTypes.string.isRequired,
+  skill_id: PropTypes.string.isRequired,
+  closeModal: PropTypes.func.isRequired,
+};
+
+export default SkillReviewsForm;

--- a/src/SkillReviewsForm.test.jsx
+++ b/src/SkillReviewsForm.test.jsx
@@ -18,7 +18,7 @@ describe('<SkillReviewsForm />', () => {
     const wrapper = mount(<SkillReviewsForm />);
     expect(wrapper.state().team_member_id).toBe('');
     const newID = '1234';
-    const event = { target: {value: newID }};
+    const event = { target: { value: newID } };
     wrapper.find({ name: 'teamMemberSelect' }).simulate('change', event);
     expect(wrapper.state().team_member_id).toBe(newID);
   });
@@ -27,17 +27,36 @@ describe('<SkillReviewsForm />', () => {
     const wrapper = mount(<SkillReviewsForm />);
     expect(wrapper.state().positive).toBe(true);
     const newVal = false;
-    const event = {target: {value: newVal}}
+    const event = { target: { value: newVal } };
     wrapper.find({ name: 'positiveSelect' }).simulate('change', event);
     expect(wrapper.state().positive).toBe(newVal);
+  });
+
+  it('should be accept Strings as ev.target.value', () => {
+    const wrapper = mount(<SkillReviewsForm />);
+    const positiveSelectElement = wrapper.find('[name="positiveSelect"]');
+    const falseEvent = {
+      target: {
+        value: 'false',
+      },
+    };
+    positiveSelectElement.simulate('change', falseEvent);
+    expect(wrapper.state().positive).toEqual(false);
+    const trueEvent = {
+      target: {
+        value: 'true',
+      },
+    };
+    positiveSelectElement.simulate('change', trueEvent);
+    expect(wrapper.state().positive).toEqual(true);
   });
 
   it('changes state when text in "Review" text area changes', () => {
     const wrapper = mount(<SkillReviewsForm />);
     const newBody = 'Little Bo Peep';
     expect(wrapper.state().body).toBe('');
-    const event = {target: {value: newBody}};
-    wrapper.find({name: 'reviewBody' }).simulate('change', event);
+    const event = { target: { value: newBody } };
+    wrapper.find({ name: 'reviewBody' }).simulate('change', event);
     expect(wrapper.state().body).toBe(newBody);
   });
 });

--- a/src/__snapshots__/SkillReviewsForm.test.jsx.snap
+++ b/src/__snapshots__/SkillReviewsForm.test.jsx.snap
@@ -51,11 +51,11 @@ exports[`<SkillReviewsForm /> matches the stored snapshot 1`] = `
           name="positiveSelect"
           onChange={[Function]}>
           <option
-            value={true}>
+            value="true">
             Yes
           </option>
           <option
-            value={false}>
+            value="false">
             No
           </option>
         </FormControl>


### PR DESCRIPTION
Fixes #95 

In `onPositiveChange`, we were setting the value stored at `ev.target.value`, which was assumed to be a Boolean type, but was actually a String type with value `'true'` or `'false'`. This PR will compare against `'true'` to determine if the review is positive or not. Would like to discuss throwing an error instead of assuming it is either `'true'` or `'false'`