### PR TITLE
Modified skill review modal sizing

### DIFF
--- a/src/AddSkillReviewForm.jsx
+++ b/src/AddSkillReviewForm.jsx
@@ -5,7 +5,8 @@ import { Button,
   ControlLabel,
   Form,
   FormControl,
-FormGroup } from 'react-bootstrap';
+  FormGroup,
+  ButtonToolbar } from 'react-bootstrap';
 
 const validateInput = (userInput) => {
   if (userInput.body === '') {
@@ -136,19 +137,20 @@ class AddSkillReviewForm extends React.Component {
               <FormControl
                 name="reviewBody"
                 componentClass="textarea"
-                style={{ height: 150 }}
                 onChange={this.onBodyChange}
               />
             </Col>
           </FormGroup>
           <FormGroup>
-            <Col smOffset={2} sm={10}>
-              <Button type="submit" bsStyle="primary">
-                Submit
-              </Button>
-              <Button onClick={this.props.onCancel} bsStyle="info">
-                Cancel
-              </Button>
+            <Col smOffset={2}>
+              <ButtonToolbar>
+                <Button type="submit" bsStyle="primary">
+                  Submit
+                </Button>
+                <Button onClick={this.props.onCancel} bsStyle="info">
+                  Cancel
+                </Button>
+              </ButtonToolbar>
             </Col>
           </FormGroup>
         </Form>

--- a/src/__snapshots__/AddSkillReviewForm.test.jsx.snap
+++ b/src/__snapshots__/AddSkillReviewForm.test.jsx.snap
@@ -78,12 +78,7 @@ exports[`<AddSkillReviewForm /> matches the stored snapshot 1`] = `
           bsClass="form-control"
           componentClass="textarea"
           name="reviewBody"
-          onChange={[Function]}
-          style={
-            Object {
-              "height": 150,
-            }
-          } />
+          onChange={[Function]} />
       </Col>
     </FormGroup>
     <FormGroup
@@ -91,26 +86,28 @@ exports[`<AddSkillReviewForm /> matches the stored snapshot 1`] = `
       <Col
         bsClass="col"
         componentClass="div"
-        sm={10}
         smOffset={2}>
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsStyle="primary"
-          disabled={false}
-          type="submit">
-          Submit
-        </Button>
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsStyle="info"
-          disabled={false}
-          onClick={undefined}>
-          Cancel
-        </Button>
+        <ButtonToolbar
+          bsClass="btn-toolbar">
+          <Button
+            active={false}
+            block={false}
+            bsClass="btn"
+            bsStyle="primary"
+            disabled={false}
+            type="submit">
+            Submit
+          </Button>
+          <Button
+            active={false}
+            block={false}
+            bsClass="btn"
+            bsStyle="info"
+            disabled={false}
+            onClick={undefined}>
+            Cancel
+          </Button>
+        </ButtonToolbar>
       </Col>
     </FormGroup>
   </Form>


### PR DESCRIPTION
Fixes #85. This PR makes the review text field smaller (I prefer it the way it is in the current master branch; but this fixes the minimization problem, to an extent).

### Maximized Window
![screen shot 2017-02-01 at 4 15 14 pm](https://cloud.githubusercontent.com/assets/10351828/22528899/ced474b8-e89a-11e6-9ee4-672860b0c7c1.png)

### Minimized Window
![screen shot 2017-02-01 at 4 14 37 pm](https://cloud.githubusercontent.com/assets/10351828/22528903/d1c8a414-e89a-11e6-95b3-1ddc30c81767.png)
(Making the browser window any smaller causes you to have to scroll to submit the review.)

There are some other changes that could potentially be made to the modal itself to maximize screen real estate when minimized to a large extent, but I didn't mess with that. I think we should leave anything like that for the UI overhaul, if we get around to doing that.

