### PR TITLE
Expand Modal Overlay to cover entire page

### DIFF
--- a/src/Styles.jsx
+++ b/src/Styles.jsx
@@ -8,9 +8,9 @@ export const ModalStyle = {
   },
   content: {
     position: 'fixed',
-    top: '250px',
-    left: '500px',
-    right: '500px',
-    bottom: '250px',
+    top: '15%',
+    left: '25%',
+    right: '25%',
+    bottom: '25%',
   }
 }

--- a/src/Styles.jsx
+++ b/src/Styles.jsx
@@ -1,10 +1,16 @@
 export const ModalStyle = {
   overlay: {
-    position: 'fixed',
-    top: '15%',
-    left: '25%',
-    right: '25%',
-    bottom: '25%',
+    position: 'absolute',
+    top: '0%',
+    left: '0%',
+    right: '0%',
+    bottom: '0%',
   },
-  content: {}
+  content: {
+    position: 'fixed',
+    top: '250px',
+    left: '500px',
+    right: '500px',
+    bottom: '250px',
+  }
 }


### PR DESCRIPTION
Modal Overlay is expanded to cover enter page so when a modal is opened, and you click anywhere outside of the modal it will close.

fixes #98 