### PR TITLE
Remove react select 150

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "react-router": "^3.0.0",
     "react-router-bootstrap": "^0.23.1",
     "react-scripts": "0.8.4",
-    "react-select": "^1.0.0-rc.2",
     "serve": "^2.1.2",
     "webpack": "^1.14.0"
   },

--- a/src/AddSkillForm.jsx
+++ b/src/AddSkillForm.jsx
@@ -43,6 +43,8 @@ class AddSkillForm extends React.Component {
   }
 
   onTypeChange(ev) {
+    console.log('addskillform typechange ev:')
+    console.log(ev);
     this.onChange('skill_type')(ev.target.value);
   }
 

--- a/src/AddSkillForm.jsx
+++ b/src/AddSkillForm.jsx
@@ -43,8 +43,6 @@ class AddSkillForm extends React.Component {
   }
 
   onTypeChange(ev) {
-    console.log('addskillform typechange ev:')
-    console.log(ev);
     this.onChange('skill_type')(ev.target.value);
   }
 

--- a/src/Skills.jsx
+++ b/src/Skills.jsx
@@ -2,8 +2,7 @@ import axios from 'axios';
 import 'bootstrap/dist/css/bootstrap.css';
 import React, { Component, PropTypes } from 'react';
 import { browserHistory } from 'react-router';
-import { Row, Col, Button, Grid } from 'react-bootstrap';
-import Select from 'react-select';
+import { Row, Col, Button, Grid, FormControl } from 'react-bootstrap';
 
 import ReviewPanel from './ReviewPanel.jsx';
 import ItemDisplayer from './ItemDisplayer';
@@ -67,7 +66,8 @@ class Skills extends Component {
 
   onSkillChange(ev) {
     // Get the ID of the selected skill
-    const skillId = ev.id;
+    const skillId = ev.target.value;
+    console.log('skillID: ' + skillId);
     // Load the current skill's info and then route the user
     return this.loadCurrentSkill(skillId)
       .then(browserHistory.push(`/skills/${skillId}`))
@@ -269,6 +269,11 @@ class Skills extends Component {
   render() {
     const currentSkillID = this.state.currentSkill.skill_id;
     const isSkillSelected = currentSkillID !== "";
+    const skillOptions = this.state.skills.map((skill, idx) =>
+      <option key={idx} value={skill.id}>
+        {skill.name}
+      </option>
+    );
     let reviews = null;
     if (this.state.reviews) {
       reviews = this.state.reviews.map(review => {
@@ -349,13 +354,13 @@ class Skills extends Component {
         <div>
           <Row>
             <Col xs={4} md={4}>
-              <Select
-                name="skills"
-                labelKey="name"
-                onChange={this.onSkillChange}
-                value={this.state.currentSkill.skill_type}
-                options={this.state.skills}
-              />
+              <FormControl 
+                name='skills'
+                componentClass='select' 
+                onChange={this.onSkillChange} >
+                {<option selected disabled>Select A Skill...</option>}
+                {skillOptions}
+              </FormControl>
             </Col>
             <WithLogin>
               <Button

--- a/src/Skills.jsx
+++ b/src/Skills.jsx
@@ -67,7 +67,6 @@ class Skills extends Component {
   onSkillChange(ev) {
     // Get the ID of the selected skill
     const skillId = ev.target.value;
-    console.log('skillID: ' + skillId);
     // Load the current skill's info and then route the user
     return this.loadCurrentSkill(skillId)
       .then(browserHistory.push(`/skills/${skillId}`))

--- a/src/Team.jsx
+++ b/src/Team.jsx
@@ -183,14 +183,6 @@ class Team extends React.Component {
               {<option selected disabled>Select A Team Member...</option>}
               {tmOptions}
             </FormControl>
-
-            {/*<Select
-              name="teamMembers"
-              labelKey="name"
-              value={this.state.selectedTeamMember.name}
-              options={this.state.teamMembers}
-              onChange={this.onSelectChange}
-            />*/}
           </Col>
           <WithLogin>
             <Button

--- a/src/Team.jsx
+++ b/src/Team.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import 'bootstrap/dist/css/bootstrap.css';
 import Button from 'react-bootstrap/lib/Button';
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col, FormControl } from 'react-bootstrap';
 import axios from 'axios';
 import { browserHistory } from 'react-router';
-import Select from 'react-select';
 
 import ItemDisplayer from './ItemDisplayer';
 import TeamMemberDisplay from './TeamMemberDisplay.jsx';
@@ -41,8 +40,9 @@ class Team extends React.Component {
     this.fetchTeamMembers();
   }
 
-  onSelectChange(obj) {
-    axios.get(`${api}/teammembers/${obj.id}`)
+  onSelectChange(ev) {
+    const teamMemberID = ev.target.value;
+    axios.get(`${api}/teammembers/${teamMemberID}`)
       .then((result) => {
         const teamMemberData = result.data;
         this.setState({
@@ -155,6 +155,11 @@ class Team extends React.Component {
 
   render() {
     let selectedItem = null;
+    const tmOptions = this.state.teamMembers.map((teamMember, idx) =>
+      <option key={idx} value={teamMember.id}>
+        {teamMember.name}
+      </option>
+    );
     if (this.state.selectedTeamMember.id) {
       selectedItem = (
         <ItemDisplayer
@@ -171,13 +176,21 @@ class Team extends React.Component {
       <div>
         <Row>
           <Col xs={4} md={4}>
-            <Select
+            <FormControl 
+              name='teamMembers'
+              componentClass='select' 
+              onChange={this.onSelectChange} >
+              {<option selected disabled>Select A Team Member...</option>}
+              {tmOptions}
+            </FormControl>
+
+            {/*<Select
               name="teamMembers"
               labelKey="name"
               value={this.state.selectedTeamMember.name}
               options={this.state.teamMembers}
               onChange={this.onSelectChange}
-            />
+            />*/}
           </Col>
           <WithLogin>
             <Button

--- a/src/__snapshots__/Skills.test.jsx.snap
+++ b/src/__snapshots__/Skills.test.jsx.snap
@@ -8,50 +8,17 @@ exports[`<Skills /> matches the stored snapshot 1`] = `
       componentClass="div"
       md={4}
       xs={4}>
-      <Select
-        addLabelText="Add \"{label}\"?"
-        arrowRenderer={[Function]}
-        autosize={true}
-        backspaceRemoves={true}
-        backspaceToRemoveMessage="Press backspace to remove {label}"
-        clearAllText="Clear all"
-        clearRenderer={[Function]}
-        clearValueText="Clear value"
-        clearable={true}
-        deleteRemoves={true}
-        delimiter=","
-        disabled={false}
-        escapeClearsValue={true}
-        filterOptions={[Function]}
-        ignoreAccents={true}
-        ignoreCase={true}
-        inputProps={Object {}}
-        isLoading={false}
-        joinValues={false}
-        labelKey="name"
-        matchPos="any"
-        matchProp="any"
-        menuBuffer={0}
-        menuRenderer={[Function]}
-        multi={false}
+      <FormControl
+        bsClass="form-control"
+        componentClass="select"
         name="skills"
-        noResultsText="No results found"
-        onBlurResetsInput={true}
-        onChange={[Function]}
-        onCloseResetsInput={true}
-        openAfterFocus={false}
-        optionComponent={[Function]}
-        options={Array []}
-        pageSize={5}
-        placeholder="Select..."
-        required={false}
-        scrollMenuIntoView={true}
-        searchable={true}
-        simpleValue={false}
-        tabSelectsValue={true}
-        value=""
-        valueComponent={[Function]}
-        valueKey="value" />
+        onChange={[Function]}>
+        <option
+          disabled={true}
+          selected={true}>
+          Select A Skill...
+        </option>
+      </FormControl>
     </Col>
     <WithLogin>
       <Button

--- a/src/__snapshots__/Team.test.jsx.snap
+++ b/src/__snapshots__/Team.test.jsx.snap
@@ -8,50 +8,17 @@ exports[`<Team /> matches the stored snapshot 1`] = `
       componentClass="div"
       md={4}
       xs={4}>
-      <Select
-        addLabelText="Add \"{label}\"?"
-        arrowRenderer={[Function]}
-        autosize={true}
-        backspaceRemoves={true}
-        backspaceToRemoveMessage="Press backspace to remove {label}"
-        clearAllText="Clear all"
-        clearRenderer={[Function]}
-        clearValueText="Clear value"
-        clearable={true}
-        deleteRemoves={true}
-        delimiter=","
-        disabled={false}
-        escapeClearsValue={true}
-        filterOptions={[Function]}
-        ignoreAccents={true}
-        ignoreCase={true}
-        inputProps={Object {}}
-        isLoading={false}
-        joinValues={false}
-        labelKey="name"
-        matchPos="any"
-        matchProp="any"
-        menuBuffer={0}
-        menuRenderer={[Function]}
-        multi={false}
+      <FormControl
+        bsClass="form-control"
+        componentClass="select"
         name="teamMembers"
-        noResultsText="No results found"
-        onBlurResetsInput={true}
-        onChange={[Function]}
-        onCloseResetsInput={true}
-        openAfterFocus={false}
-        optionComponent={[Function]}
-        options={Array []}
-        pageSize={5}
-        placeholder="Select..."
-        required={false}
-        scrollMenuIntoView={true}
-        searchable={true}
-        simpleValue={false}
-        tabSelectsValue={true}
-        value=""
-        valueComponent={[Function]}
-        valueKey="value" />
+        onChange={[Function]}>
+        <option
+          disabled={true}
+          selected={true}>
+          Select A Team Member...
+        </option>
+      </FormControl>
     </Col>
     <WithLogin>
       <Button


### PR DESCRIPTION
Fixes #99, Fixes #150. This PR removes the `react-select` dependency from the project, and replaces it with Bootstrap select forms.

* <img width="625" alt="screen shot 2017-02-16 at 11 49 25 am" src="https://cloud.githubusercontent.com/assets/10351828/23033583/3ef0213a-f43e-11e6-9180-f33d03932b3a.png">
* <img width="548" alt="screen shot 2017-02-16 at 11 49 36 am" src="https://cloud.githubusercontent.com/assets/10351828/23033586/40e6f55e-f43e-11e6-8533-87f3446bacb7.png">

