### PR TITLE
Login link does not open a new tab

### DIFF
--- a/src/LoginLink.jsx
+++ b/src/LoginLink.jsx
@@ -42,7 +42,7 @@ const LoginLink = () => {
     <div>
       <a
         href={authURL}
-        target="_blank" >
+      >
         Sign in to Github
       </a>
     </div>


### PR DESCRIPTION
When clicked, the login link will open a new tab. This will end that behavior and keep the user in the same tab