### PR TITLE
Adds button and correct margins to github sign in link

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Grid from 'react-bootstrap/lib/Grid';
 import { Link } from 'react-router';
-import { Navbar, Nav, NavItem } from 'react-bootstrap';
+import { Button, Navbar, Nav, NavItem } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.css';
 
 import LoginLink from './LoginLink.jsx';
@@ -29,8 +29,13 @@ class Header extends React.Component {
               <Link to="/team">Team</Link>
             </NavItem>
           </Nav>
-          <Nav pullRight>
+          <Nav pullRight >
+
+            <Button
+              bsStyle='primary'
+              style={{ marginTop: '5%', marginRight: '5%' }}  >
               <LoginLink />
+            </Button>
           </Nav>
         </Navbar>
         {this.props.children}

--- a/src/LoginLink.jsx
+++ b/src/LoginLink.jsx
@@ -41,7 +41,7 @@ const LoginLink = () => {
   return (
     <div>
       <a
-        style={{ color: 'white'}}
+        style={{ color: 'white' }}
         href={authURL}
       >
         Sign in to Github

--- a/src/LoginLink.jsx
+++ b/src/LoginLink.jsx
@@ -41,6 +41,7 @@ const LoginLink = () => {
   return (
     <div>
       <a
+        style={{ color: 'white'}}
         href={authURL}
       >
         Sign in to Github

--- a/src/__snapshots__/Header.test.jsx.snap
+++ b/src/__snapshots__/Header.test.jsx.snap
@@ -51,7 +51,20 @@ exports[`<Header /> matches the stored snapshot 1`] = `
       pullLeft={false}
       pullRight={true}
       stacked={false}>
-      <LoginLink />
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="primary"
+        disabled={false}
+        style={
+          Object {
+            "marginRight": "5%",
+            "marginTop": "5%",
+          }
+        }>
+        <LoginLink />
+      </Button>
     </Nav>
   </Uncontrolled(Navbar)>
 </Grid>


### PR DESCRIPTION
Adds button and correct margins to Github sign in link. Dane suggested using the Octocat rather than text to display the Github link. I also believe it is a good idea, but figured I'd make a new story for it if we decide to go that way.